### PR TITLE
Fix missing RemoteLink export

### DIFF
--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -11,7 +11,6 @@ import {
   updateStoresWorkflow,
 } from "@medusajs/core-flows";
 import { Logger } from "@medusajs/medusa";
-import { RemoteLink } from "@medusajs/modules-sdk";
 import { ExecArgs } from "@medusajs/types";
 import {
   ContainerRegistrationKeys,
@@ -30,7 +29,7 @@ const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:3000";
 
 export default async function seedDemoData({ container }: ExecArgs) {
   const logger: Logger = container.resolve(ContainerRegistrationKeys.LOGGER);
-  const remoteLink: RemoteLink = container.resolve(
+  const remoteLink = container.resolve(
     ContainerRegistrationKeys.REMOTE_LINK
   );
   const fulfillmentModuleService = container.resolve(


### PR DESCRIPTION
## Summary
- avoid importing `RemoteLink` type from `@medusajs/modules-sdk`
- resolve remoteLink service without explicit type

## Testing
- `yarn test:unit` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_684c289e2de883328de9cd80ce8fc7ee