### PR TITLE
Fix medusa build missing dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,8 @@
     "lucide-react": "^0.379.0",
     "pg": "^8.13.0",
     "prism-react-renderer": "^2.0.4",
-    "prop-types": "^15.8.1"
+    "prop-types": "^15.8.1",
+    "zod": "^3.25.64"
   },
   "devDependencies": {
     "@medusajs/test-utils": "2.0.0",

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -13145,6 +13145,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.6.2"
     vite: "npm:^5.2.11"
+    zod: "npm:^3.25.64"
   languageName: unknown
   linkType: soft
 
@@ -16560,5 +16561,12 @@ __metadata:
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 10c0/7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.64":
+  version: 3.25.64
+  resolution: "zod@npm:3.25.64"
+  checksum: 10c0/00d76093a999e377e4ffd037fa7185e861c35917e8c4272f514115c206a0654995168f57fb71708b11e0a9243206d988b7f63b543404e1796402e50d346a6bd7
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary
- add `zod` dependency so `npx medusa build` succeeds

## Testing
- `yarn test:unit --passWithNoTests`
- `npx medusa build`

------
https://chatgpt.com/codex/tasks/task_e_684c2cdd880c8332bf62b8c80b650abd